### PR TITLE
Allow target variables to be passed from the environment

### DIFF
--- a/aws-cli/get-aws-subaccount-session.sh
+++ b/aws-cli/get-aws-subaccount-session.sh
@@ -47,13 +47,15 @@ echo
 echo Loading AWS CLI configs...
 echo
 
-#### alter the values below to your target subaccount and target role as needed ## 
+#### alter the values below to your target subaccount and target role as needed ##
+#### You may set these environment variables before sourcing the
+#### script to override the default values.
 
-export AWS_PROFILE=default
-export aws_target_subaccount_name=gross-eng-dev
-export aws_target_subaccount_id=235758441054
-export aws_target_subaccount_role=isc-login_assumed-role_eng_power-users
-export aws_target_subaccount_session_seconds=3600
+export AWS_PROFILE=${AWS_PROFILE:-default}
+export aws_target_subaccount_name=${aws_target_subaccount_name:-gross-eng-dev}
+export aws_target_subaccount_id=${aws_target_subaccount_id:-235758441054}
+export aws_target_subaccount_role=${aws_target_subaccount_role:-isc-login_assumed-role_eng_power-users}
+export aws_target_subaccount_session_seconds=${aws_target_subaccount_session_seconds:-3600}
 
 ##################################################################################
 

--- a/aws-cli/get-aws-subaccount-session.sh
+++ b/aws-cli/get-aws-subaccount-session.sh
@@ -120,9 +120,16 @@ echo
 
 #### this content is sourced from https://github.com/sweharris/aws-cli-mfa/blob/master/get-aws-creds and has been modified a bit ##
 
-# This uses MFA devices to get temporary (eg 1 hour) credentials.
+# This uses MFA devices to get temporary (eg 12 hour) credentials.  Requires
+# a TTY for user input.
 #
 # GPL 2 or higher
+
+if [ ! -t 0 ]
+then
+  echo Must be on a tty >&2
+  return
+fi
 
 if [ -n "$AWS_SESSION_TOKEN" ]
 then

--- a/aws-cli/get-aws-subaccount-session.sh
+++ b/aws-cli/get-aws-subaccount-session.sh
@@ -120,16 +120,9 @@ echo
 
 #### this content is sourced from https://github.com/sweharris/aws-cli-mfa/blob/master/get-aws-creds and has been modified a bit ##
 
-# This uses MFA devices to get temporary (eg 12 hour) credentials.  Requires
-# a TTY for user input.
+# This uses MFA devices to get temporary (eg 1 hour) credentials.
 #
 # GPL 2 or higher
-
-if [ ! -t 0 ]
-then
-  echo Must be on a tty >&2
-  return
-fi
 
 if [ -n "$AWS_SESSION_TOKEN" ]
 then


### PR DESCRIPTION
With this change you can pass the `AWS_PROFILE` and `aws_target_subaccount_...` settings using environment variables. This is a handy improvement for non-interactive usage (but you still have to comment out the part that checks for a TTY for that).